### PR TITLE
Add the possibility to deactivate group membership filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,18 @@ c.LDAPAuthenticator.user_search_filter = '(&(objectClass=person)(sAMAccountName=
 c.LDAPAuthenticator.user_membership_attribute = 'memberOf'
 ```
 
+
+<dl>
+  <dt>LDAPAuthenticator.filter_by_group</dt>
+  <dd>Boolean used to activate or deactivate group membership filtering (defaults to 'True').</dd>
+</dl>
+
+```python
+# example
+c.LDAPAuthenticator.filter_by_group = False
+```
+
+
 <dl>
   <dt>LDAPAuthenticator.group_search_base</dt>
   <dd>The location in the Directory Information Tree where the group search will start.

--- a/ldapauthenticator/ldapauthenticator.py
+++ b/ldapauthenticator/ldapauthenticator.py
@@ -165,6 +165,14 @@ class LDAPAuthenticator(Authenticator):
         have that value substituted with the username of the authenticating user.
         """
     )
+    
+    filter_by_group = Bool(
+        default_value=True,
+        config=True,
+        help="""
+        Boolean specifying if the group membership filtering is enabled or not.
+        """
+    )
 
     user_membership_attribute = Unicode(
         default_value='memberOf',
@@ -532,7 +540,7 @@ class LDAPAuthenticator(Authenticator):
 
                 # is authenticating user a member of permitted_groups
                 allowed_memberships = list(set(auth_user_memberships).intersection(permitted_groups))
-                if bool(allowed_memberships):
+                if bool(allowed_memberships) or not self.filter_by_group:
                     self.log.debug(
                         "User '%s' found in the following allowed ldap groups %s. Proceeding with authentication.",
                         username, allowed_memberships)


### PR DESCRIPTION
Hello Ryan,
I'm actually using your ldap authenticator for Jupyterhub (which is really good, thank you). I encoutered a compatibility issue with my server. 
My old openLdap server doesn't use the "memberOf" attribute, so in order to verify membership I need to write a lot of code in order to get members from groups and do the tests. This solution was to heavy for me, and I don't need to use group filtering, so I prefered to had an option to deactivate group filtering the simplest way.
Hope you will accept my help, and if you want me to improve my merge request, please ask me.

Best regards,
Thomas